### PR TITLE
fix: duplicate selected network button when resizing from small to large

### DIFF
--- a/src/components/globals/recent_metrics/NetworkSelector.tsx
+++ b/src/components/globals/recent_metrics/NetworkSelector.tsx
@@ -23,6 +23,7 @@ function NetworkSelector({
             setEndIndex(3);
         } else {
             setEndIndex(1);
+			setIsMoreSelected(false);
         }
     }, [width]);
 

--- a/src/components/globals/recent_metrics/NetworkSelector.tsx
+++ b/src/components/globals/recent_metrics/NetworkSelector.tsx
@@ -23,7 +23,7 @@ function NetworkSelector({
             setEndIndex(3);
         } else {
             setEndIndex(1);
-			setIsMoreSelected(false);
+            setIsMoreSelected(false);
         }
     }, [width]);
 


### PR DESCRIPTION
Fixing the issue specified in last comment of https://github.com/jiffy-labs/jiffyscan-frontend/issues/14 about duplicate network buttons selected when resizing the window from small to large.