### PR TITLE
Fix/154 update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you want to contribute to the project by fixing a bug or adding a new feature
 -   Create a new branch from the `development` branch.
 -   Make your changes and commit them.
 -   Push your branch to your forked repository.
--   Open a pull request from your branch to the main branch of the original repository.
+-   Open a pull request from your branch to the development branch of the original repository.
 
 When submitting a pull request, please include a clear description of your changes and why you made them. Please make sure your code follows our coding standards and is well-documented.
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ bash
 
 `git clone https://github.com/jiffy-labs/jiffyscan-frontend.git`
 
-and switch to the branch `ui-work`
+and switch to the branch `development`
 
-`git switch ui-work && git pull`
+`git switch development && git pull`
+
+work on development branch and raise a PR to develpoment branch
 
 Once you have the code, you can install the dependencies by running:
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you've found a bug in Jiffyscan, please open a new issue on GitHub. Be sure t
 If you want to contribute to the project by fixing a bug or adding a new feature, please submit a pull request. Here's how:
 
 -   Fork the repository.
--   Create a new branch from the `ui-work` branch.
+-   Create a new branch from the `development` branch.
 -   Make your changes and commit them.
 -   Push your branch to your forked repository.
 -   Open a pull request from your branch to the main branch of the original repository.


### PR DESCRIPTION
This PR updates the readme file fixing the issue #154 "unable to switch to ui-work branch", instead work on development branch.

![image](https://github.com/jiffy-labs/jiffyscan-frontend/assets/79032848/027fac0a-5f9e-48ff-91a5-4166340998a6)
