### PR TITLE
handled TypeError in HeaderSection

### DIFF
--- a/src/components/global/HeaderSection.tsx
+++ b/src/components/global/HeaderSection.tsx
@@ -107,18 +107,21 @@ const HeaderSectionGlobal: React.FC<HeaderSectionProps> = ({
                                 )}
                             </div>
                         </div>
-                        {item?.address !== '' && addressMapping && addressMapping[item?.address.toLowerCase()] && POWERED_BY_LOGO_MAP[addressMapping[item?.address.toLowerCase()].company.toLowerCase()] && (
-                            <div className="md:px-[16px] px-0 md:py-[8px] py-0">
-                                <span className="text-bluegrey-300 text-[10px] leading-5 flex items-center gap-2 font-normal">
-                                    Powered By{' '}
-                                    <img
-                                        src={POWERED_BY_LOGO_MAP[addressMapping[item?.address.toLowerCase()].company.toLowerCase()].small}
-                                        style={{ height: 20, width: 20 }}
-                                        alt=""
-                                    />
-                                </span>
-                            </div>
-                        )}
+                        {item?.address && typeof item.address === 'string' && addressMapping && 
+    addressMapping[item.address.toLowerCase()] && 
+    addressMapping[item.address.toLowerCase()].company &&
+    POWERED_BY_LOGO_MAP[addressMapping[item.address.toLowerCase()].company.toLowerCase()] && (
+    <div className="md:px-[16px] px-0 md:py-[8px] py-0">
+        <span className="text-bluegrey-300 text-[10px] leading-5 flex items-center gap-2 font-normal">
+            Powered By{' '}
+            <img
+                src={POWERED_BY_LOGO_MAP[addressMapping[item.address.toLowerCase()].company.toLowerCase()].small}
+                style={{ height: 20, width: 20 }}
+                alt=""
+            />
+        </span>
+    </div>
+)}
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
TypeError
Cannot read properties of undefined (reading 'toLowerCase') Line 110 in "src/components/global/HeaderSection"
This error appeared in Sentry in last 24 hours, few bundler urls were failing like:
![image](https://github.com/user-attachments/assets/c1f8d97e-8db6-4e15-8168-3aea027ba9d4)


->https://jiffyscan.xyz/bundler/0x6A6334b772ac57D7d039E5b42d14468fDD7997c9?network=matic&pageNo=0&pageSize=10
->https://jiffyscan.xyz/bundler/0x4337053498BF3De9BaB4D55a345F727DBa05d6aF?network=matic

There were potentially **undefined** `addressMapping` Entries or `company` field.

Added a few more checks to prevent trying to access properties on `undefined` values

**_Changes:_**

->Checking item?.address:

Ensures item and item.address are defined.
The typeof item.address === 'string' check ensures that item.address is a string before trying to call toLowerCase().

->Checking addressMapping[item.address.toLowerCase()]:

Verifies that addressMapping has an entry for the given address before accessing it.

->Checking addressMapping[item.address.toLowerCase()].company:

Ensures that the company field exists before attempting to call toLowerCase() on it.
